### PR TITLE
Better response logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ All arguments after the options are passed directly to the Claude CLI.
 ### Options
 
 - `--log_dir=DIR`: Directory to save logs (default: ~/.claude_logs)
-- `--save-responses`: Also save response data (default: off)
 - `--print`: Show debug messages (default: off)
 
 ### Examples
@@ -55,9 +54,6 @@ claude-log
 
 # Run Claude with a prompt
 claude-log -p "What is Rust and why do people care?"
-
-# Save both requests and responses
-claude-log --save-responses
 
 # Specify a custom log directory
 claude-log --log_dir=/path/to/logs

--- a/bin/claude-log
+++ b/bin/claude-log
@@ -4,15 +4,9 @@
  * Claude API Logger - Simple wrapper script
  */
 
-const { execSync } = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const path = require("path");
 
 // Locate the claude-logger main script
-const mainScriptPath = path.resolve(__dirname, '../claude_logger.js');
-
-// Forward all arguments to the main script
-process.argv.splice(1, 1);
-process.argv[0] = mainScriptPath;
+const mainScriptPath = path.resolve(__dirname, "../claude_logger.js");
 
 require(mainScriptPath);

--- a/claude_logger.js
+++ b/claude_logger.js
@@ -2,7 +2,7 @@
 
 /**
  * Claude API Logger - Captures Claude API requests and responses
- * Usage: claude-log [--log_dir=DIR] [--save-responses] [claude options]
+ * Usage: claude-log [--log_dir=DIR] [claude options]
  */
 
 const fs = require("fs");
@@ -14,7 +14,6 @@ const os = require("os");
 // Parse command line arguments
 const args = process.argv.slice(2);
 let logDir = path.join(os.homedir(), ".claude_logs");
-let skipResponses = true;
 let printDebug = false;
 let claudeArgs = [];
 
@@ -26,8 +25,6 @@ for (let i = 0; i < args.length; i++) {
   } else if (arg === "--log_dir" && i < args.length - 1) {
     logDir = args[i + 1];
     i++;
-  } else if (arg === "--save-responses") {
-    skipResponses = false;
   } else if (arg === "--print") {
     printDebug = true;
   } else {
@@ -59,7 +56,6 @@ console.log("Initializing request capture...");
 const captureEnv = {
   ...process.env,
   CLAUDE_API_LOG_FILE: logFile,
-  CLAUDE_LOG_RESPONSES: skipResponses ? "false" : "true",
   CLAUDE_DEBUG: printDebug ? "true" : "false",
   NODE_OPTIONS: `--require "${path.join(__dirname, "direct_capture.js")}"`,
 };


### PR DESCRIPTION
1. Do not modify process.argv

   It confuses arg parsing (`process.argv.slice(2)`) when called via the binary.

   *This was motivated by `--save-responses` being ignored.*

2. Log requests and responses in a single file as an array of `{ request: ..., response: ... }` objects

   This also adds decompression for responses with Content-Encoding, and minor cleanup.

   *Having things in one files makes parsing responses much easier.*

3. Always save responses

   This seems like reasonable default behavior
   
-----------

Feel free to make changes to this as you see fit -- this was just some quick modifications I found helpful, so I thought I'd share them.